### PR TITLE
Remove reference to FTP info

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ conda env remove -n iblenv
 
 Install all the repositories in develop mode:
 ```
+conda config --set channel_priority false
 conda env create -f ./iblenv/iblenv.yaml
 conda activate iblenv
 conda develop ./ibllib-repo

--- a/docs_gh_pages/06_examples.rst
+++ b/docs_gh_pages/06_examples.rst
@@ -22,6 +22,8 @@ Ephys
    notebooks_external/docs_plot_sound_spectrogram_ephysrig
    notebooks_external/docs_load_spike_sorting
    notebooks_external/docs_raw_data_decompress
+   notebooks_external/docs_scatter_raster_plot
+   notebooks_external/docs_explore_passive
 
 ONE
 ###
@@ -48,6 +50,7 @@ Video
    :maxdepth: 1
 
    notebooks_external/docs_access_DLC
+   notebooks_external/docs_load_video
 
 
 

--- a/docs_gh_pages/dj_docs/dj_credentials.md
+++ b/docs_gh_pages/dj_docs/dj_credentials.md
@@ -84,17 +84,11 @@ dj.conn()
 ```
 
 You should find that Datajoint automatically connects to the database! Finally, let's make sure we save these 
-credentials into the local config file by typing,
+credentials into a global config file by typing,
 
 ```python
-dj.config.save_local()
+dj.config.save_global()
 ```
-
-To save the credentials globally so that the config file can be seen from any directory, we can type, 
- 
-```python 
-dj.config.save_global() 
-``` 
 
 Now that these credentials have been configured, every time you type `import datajoint as dj` it will automatically 
 connect to the correct database and log you in. Let's go to the next session, to get started with using Datajoint with 

--- a/docs_gh_pages/notebooks/dj_basics/dj_basics.ipynb
+++ b/docs_gh_pages/notebooks/dj_basics/dj_basics.ipynb
@@ -87,7 +87,7 @@
    "metadata": {},
    "source": [
     "```\n",
-    "dj.Diagram()\n",
+    "dj.Diagram(subject)\n",
     "```"
    ]
   },

--- a/docs_gh_pages/notebooks/one_intro/one_intro.ipynb
+++ b/docs_gh_pages/notebooks/one_intro/one_intro.ipynb
@@ -134,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see this contains information about the date of the session and so we can quickly collect a list dates for all the training sessions"
+    "We can see this contains information about the date of the session and so we can quickly collect a list of dates for all the training sessions"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The latest training session date is returned first. For convenienve let's reverse the list so that the first training session day is at index 0, for consistency we must reverse the list of eids as well "
+    "The latest training session date is returned first. For convenience let's reverse the list so that the first training session day is at index 0, for consistency we must reverse the list of eids as well "
    ]
   },
   {
@@ -206,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively we can take advantage of the ALF file format and download all files that have the prefix trials. "
+    "Alternatively we can take advantage of the ALF file format and download all files that have the prefix \"trials\". "
    ]
   },
   {
@@ -380,7 +380,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have three values 1 which indicates a 100 % visual stimulus contrast, 0.5 which corresponds to a 50 % visual contrast and whole load of nans....."
+    "We have three values: 1 which indicates a 100 % visual stimulus contrast, 0.5 which corresponds to a 50 % visual contrast and whole load of nans....."
    ]
   },
   {
@@ -391,14 +391,14 @@
     }
    },
    "source": [
-    "If we inspect `trials.contrastRight` we will find that all the indices that contain nans in the `trials.contrastLeft` are filled in `trials.contrastRight`, and vice versa. nans in the `trials.contrastLeft` and `trials.contrastRight` datasets indicate that the contrast was show on the oppisite side."
+    "If we inspect `trials.contrastRight` we will find that all the indices that contain nans in the `trials.contrastLeft` are filled in `trials.contrastRight`, and vice versa. nans in the `trials.contrastLeft` and `trials.contrastRight` datasets indicate that the contrast was shown on the opposite side."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets combine `trials.contrastLeft` and `trials.contrastRight` into a new dataset called `trials.contrast`. By convetion in the IBL, contrasts that appear on the left are assigned a negative while those on the right are positive. Let's also reflect this convention when forming our new dataset"
+    "Lets combine `trials.contrastLeft` and `trials.contrastRight` into a new dataset called `trials.contrast`. By convention in the IBL, contrasts that appear on the left are assigned a negative value while those on the right are positive. Let's also reflect this convention when forming our new dataset"
    ]
   },
   {
@@ -421,7 +421,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can inspect how many of each type of contrast was presented to the subject"
+    "We can inspect how often each type of contrast was presented to the subject"
    ]
   },
   {
@@ -439,7 +439,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally let's look at how the mouse performed on the first day of training. This information is stored in the `feedbackType` attribute of the `trials` object. A positive feedback (+1) means the mouse got the task correct, whereas a negavtive feedback (-1) means the mouse got the trial wrong. Let's double check that these are the only values we see in `trials.feedbakType`"
+    "Finally let's look at how the mouse performed on the first day of training. This information is stored in the `feedbackType` attribute of the `trials` object. A positive feedback (+1) means the mouse did the task correctly, whereas a negavtive feedback (-1) means the mouse got the trial wrong. Let's double check that these are the only values we see in `trials.feedbackType`"
    ]
   },
   {
@@ -506,7 +506,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As the mice learns the task we expect its performance to improve. Let's repeat the steps above and see how the same mouse performed on day 15 of trainng"
+    "As the mice learns the task we expect its performance to improve. Let's repeat the steps above and see how the same mouse performed on day 15 of training"
    ]
   },
   {
@@ -539,36 +539,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice how on day 15 the mouse has not only has trials with 100 % and 50 % visual stimuli contrast but also 25 % and 12.5 %. This follows the IBL training protocol where harder contrasts are introduced as the mouse becomes more expert at the task. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "eid_day15 = eids[14]\n",
-    "trials_day15 = one.load_object(eid_day15, obj=d_object)\n",
-    "n_trials_day15 = len(trials_day15.choice)\n",
-    "\n",
-    "trials_day15.contrast = np.empty((n_trials_day15))\n",
-    "contrastRight_idx = np.where(~np.isnan(trials_day15.contrastRight))[0]\n",
-    "contrastLeft_idx = np.where(~np.isnan(trials_day15.contrastLeft))[0]\n",
-    "\n",
-    "trials_day15.contrast[contrastRight_idx] = trials_day15.contrastRight[contrastRight_idx]\n",
-    "trials_day15.contrast[contrastLeft_idx] = -1 * trials_day15.contrastLeft[contrastLeft_idx]\n",
-    "\n",
-    "contrasts, n_contrasts = np.unique(trials_day15.contrast, return_counts=True)\n",
-    "print(f\"Visual stimulus contrasts on day 15 = {contrasts * 100}\")\n",
-    "print(f\"No. of each contrast on day 15 = {n_contrasts}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Notice how on day 15 the mouse has not only has trials with 100 % and 50 % visual stimuli contrast but also 25 % and 12.5 %. This follows the IBL training protocol where harder contrasts are introduced as the mouse becomes more expert at the task. "
+    "Notice how on day 15 the mouse not only has trials with 100 % and 50 % visual stimulus contrast but also 25 % and 12.5 %. This follows the IBL training protocol where harder contrasts are introduced as the mouse becomes more expert at the task. "
    ]
   },
   {
@@ -585,7 +556,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The performance has vastly improved compared to day 1 of training! Once again let's break this down further into the performance at each contrast and creata a plot of rightward choice vs signed contrast"
+    "The performance has vastly improved compared to day 1 of training! Once again let's break this down further into the performance at each contrast and create a plot of rightward choice vs signed contrast"
    ]
   },
   {
@@ -638,7 +609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs_gh_pages/notebooks/one_intro/one_intro.ipynb
+++ b/docs_gh_pages/notebooks/one_intro/one_intro.ipynb
@@ -221,7 +221,7 @@
     "\n",
     "Note\n",
     "\n",
-    "This would be called loading all attributes associated with the trials object. See [here](../../04_reference#ALF) for more information on the ALF file naming convention that is used in the IBL.\n",
+    "This would be called loading all attributes associated with the trials object. See [here](../../one_docs/one_reference.html#alf) for more information on the ALF file naming convention that is used in the IBL.\n",
     "\n",
     "</div>\n"
    ]

--- a/docs_gh_pages/one_docs/one_credentials.md
+++ b/docs_gh_pages/one_docs/one_credentials.md
@@ -35,9 +35,8 @@ HTTP_DATA_SERVER_LOGIN: # Keep default - should be automatically set as: iblmemb
 Alyx password:          # Input your Alyx password
 FlatIron HTTP password:	# Input FlatIron password
 ```
-The entries that you will need to change from default are: `ALYX_LOGIN`, `ALYX_URL`, `Alyx password`, 
-`FlatIron HTTP password` and `FlatIron FTP password`. You can also optionally change the `CACHE_DIR` (the local 
-directory where downloaded files will be saved). For the remaining entries keep the default values by pressing 
+The entries that you will need to change from default are: `ALYX_LOGIN`, `ALYX_URL`, `Alyx password` and `FlatIron HTTP password`. You can also optionally change the `CACHE_DIR` (the local
+directory where downloaded files will be saved). For the remaining entries keep the default values by pressing
 the Enter key.
 
 Once you have completed the setup process the location where the *.one_params* is saved will be printed in the python
@@ -55,9 +54,6 @@ Double check that the file has been created in the correct location and that the
     "ALYX_PWD": "alyx_password",
     "ALYX_URL": "https://alyx.internationalbrainlab.org",
     "CACHE_DIR": "cache directory that you chose",
-    "FTP_DATA_SERVER": "ftp://ibl.flatironinstitute.org",
-    "FTP_DATA_SERVER_LOGIN": "iblftp",
-    "FTP_DATA_SERVER_PWD": "flatiron_password",
     "HTTP_DATA_SERVER": "http://ibl.flatironinstitute.org",
     "HTTP_DATA_SERVER_LOGIN": "iblmember",
     "HTTP_DATA_SERVER_PWD": "flatiron_password",

--- a/docs_gh_pages/one_docs/one_matlab_installation.md
+++ b/docs_gh_pages/one_docs/one_matlab_installation.md
@@ -45,10 +45,7 @@ ALYX_LOGIN 				% Input your IBL user name
 ALYX_PWD				% Input your IBL password
 ALYX_URL:				% Should be automatically set as: https://alyx.internationalbrainlab.org - press ENTER
 CACHE_DIR:				% Local repository, can ammend or press ENTER
-FTP_DATA_SERVER: 		% Should be automatically set as: ftp://ibl.flatironinstitute.org - press ENTER
-FTP_DATA_SERVER_LOGIN:	% Should be automatically set as: iblftp - press ENTER
-FTP_DATA_SERVER_PWD		% Request Password for FTP from Olivier
-HTTP_DATA_SERVER: 		% Should be automatically set as: http://ibl.flatironinstitute.org  - press ENTER 
+HTTP_DATA_SERVER: 		% Should be automatically set as: http://ibl.flatironinstitute.org  - press ENTER
 HTTP_DATA_SERVER_LOGIN: % Should be automatically set as: iblmember  - press ENTER
 HTTP_DATA_SERVER_PWD	% Request Password for HTTP from Olivier
 ```

--- a/docs_gh_pages/one_docs/one_onelight.md
+++ b/docs_gh_pages/one_docs/one_onelight.md
@@ -6,7 +6,7 @@ is hierachically organised into sub-folders and file-names that match the ONE co
 supports data that has been uploaded to a webserver, to figshare (a site offering free hosting of scientific data) or 
 that is stored on a user's local machine. For an example implementation of ONE Light and more information about how to 
 use this interface to automatically upload data to figshare, please refer to this 
-[page](https://github.com/int-brain-lab/ibllib/tree/onelight/).
+[page](https://github.com/int-brain-lab/ibllib/tree/master/oneibl).
 
 The behavioural data associated with the IBL paper: [A standardized and reproducible method to measure decision-making 
 in mice](https://doi.org/10.1101/2020.01.17.909838) has been made available through the ONE Light interface. To get 

--- a/docs_gh_pages/one_docs/one_reference.md
+++ b/docs_gh_pages/one_docs/one_reference.md
@@ -90,7 +90,7 @@ ALF can deal with any sort of file, as long as it has a concept of a number of r
 
 .tsv: tab-delimited text file. This is recommended over comma-separated files since text fields often have commas in. All rows should have the same number of columns. The first row contains tab-separated names for each column.
 
-.bin: flat binary file. It's better to use .npy for storing binary dat,a but some recording systems save in flat binary. Rather than convert them, you can ALFize a flat binary file by adding a metadata file, which specifies the number of columns (as the size of the "columns" array) and the binary datatype as a top-level key "dtype", using numpy naming conventions.
+.bin: flat binary file. It's better to use .npy for storing binary data but some recording systems save in flat binary. Rather than convert them, you can ALFize a flat binary file by adding a metadata file, which specifies the number of columns (as the size of the "columns" array) and the binary datatype as a top-level key "dtype", using numpy naming conventions.
 
 ### Relations
 

--- a/iblenv.yaml
+++ b/iblenv.yaml
@@ -27,7 +27,7 @@ dependencies:
  - pillow
  - pip
  - plotly
- - pyarrow
+ - conda-forge::pyarrow
  - pynrrd
  - pyopengl
  - pyqt >= 5.12


### PR DESCRIPTION
Removing leftover reference to FTP support in ONE docs. Not sure if to PR to master or docs_develop