### PR TITLE
Updates to the iblenv YAML file for MacOS and stability

### DIFF
--- a/iblenv.yaml
+++ b/iblenv.yaml
@@ -39,6 +39,7 @@ dependencies:
  - scikit-learn
  - scipy >=1.4.1
  - seaborn
+ - pysoundfile
  - statsmodels
  - tqdm
  - pip:
@@ -48,4 +49,3 @@ dependencies:
    - mtscomp
    - opencv-python
    - SimpleITK
-   - soundfile

--- a/iblenv.yaml
+++ b/iblenv.yaml
@@ -4,8 +4,8 @@ channels:
   - defaults
   - conda-forge
 dependencies:
- - python >=3.8
- - apptools >=4.5.0
+ - python >= 3.8
+ - apptools >= 4.5.0
  - click
  - colorcet
  - colorlog
@@ -45,7 +45,7 @@ dependencies:
  - nodejs
  - pip:
    - --pre
-   - datajoint
+   - datajoint == 0.12.8
    - graphviz
    - mtscomp
    - opencv-python

--- a/iblenv.yaml
+++ b/iblenv.yaml
@@ -42,6 +42,7 @@ dependencies:
  - pysoundfile
  - statsmodels
  - tqdm
+ - nodejs
  - pip:
    - --pre
    - datajoint


### PR DESCRIPTION
This pull request addresses some minor problems with the current environment file.

Currently, pysoundfile was loaded from pip, shifting it to anaconda makes the name platform independent.
NodeJS needs to be installed (at least on MacOS) so it is added as a dependency.
Datajoint library currently isn't pinned and development versions have introduced bugs.
Based on [recommendation](https://int-brain-lab.slack.com/archives/CB13FQFK4/p1612798653014500) from Shan Shen, pin to stable version.
