### PR TITLE
Remove pytorch from environment list

### DIFF
--- a/iblenv.yaml
+++ b/iblenv.yaml
@@ -1,6 +1,5 @@
 name: iblenv
 channels:
-  - pytorch
   - defaults
   - conda-forge
 dependencies:

--- a/iblenv.yaml
+++ b/iblenv.yaml
@@ -33,7 +33,6 @@ dependencies:
  - pyqt >= 5.12
  - pyqtgraph
  - pytest
- - pytorch
  - requests
  - scikits-bootstrap
  - scikit-learn

--- a/iblenv.yaml
+++ b/iblenv.yaml
@@ -8,7 +8,6 @@ dependencies:
  - click
  - colorcet
  - colorlog
- - cpuonly
  - cython
  - dataclasses
  - flake8


### PR DESCRIPTION
Pytorch is kind of a nightmare to install. While there is still some legacy code on master/develop that uses it for the GLMs, I think we are better served removing it for everyone's sake.