### PR TITLE
Add ageing dataset release to documentation

### DIFF
--- a/docs_gh_pages/index.rst
+++ b/docs_gh_pages/index.rst
@@ -65,6 +65,7 @@ IBL has released a suite of tools to process and visualize our data.
 
    notebooks_external/2025_data_release_autism_noel
    notebooks_external/2025_data_release_autism_davatolhagh
+   notebooks_external/2025_data_release_aging_zang
    notebooks_external/2022_data_release_spikesorting_benchmarks
    public_docs/data_release_pilot
 


### PR DESCRIPTION
## Summary

- Add the Zang et al. ageing dataset release page to the project-dataset navigation.
- Coordinate with int-brain-lab/ibllib#1138 for the page source.

## Verification

The full Sphinx site builds successfully using the documented local documentation-only build, and the new page returns HTTP 200 from the local preview server.