### PR TITLE
Deploy ageing dataset documentation

### DIFF
--- a/docs_gh_pages/index.rst
+++ b/docs_gh_pages/index.rst
@@ -65,6 +65,7 @@ IBL has released a suite of tools to process and visualize our data.
 
    notebooks_external/2025_data_release_autism_noel
    notebooks_external/2025_data_release_autism_davatolhagh
+   notebooks_external/2025_data_release_aging_zang
    notebooks_external/2022_data_release_spikesorting_benchmarks
    public_docs/data_release_pilot
 


### PR DESCRIPTION
## Summary

Promote the tested documentation branch to production after the successful staging build.

Includes the navigation entry for the Zang et al. ageing dataset release. The page source is promoted through the companion ibllib docs-to-develop PR.

## Verification

Build Docs workflow run 32746128370 completed successfully, and the rendered staging page was verified.